### PR TITLE
メソッドをさらに分割してReantlクラスに移動

### DIFF
--- a/main.rb
+++ b/main.rb
@@ -17,6 +17,24 @@ class Rental
 	def initialize(movie, days_rented)
 		@movie, @days_rented = movie, days_rented
 	end
+
+	def charge
+		this_amount = 0
+		case movie.price_code
+		when Movie::REGULAR
+			this_amount += 2
+			this_amount += (days_rented - 2) * 1.5 if days_rented > 2
+		when Movie::NEW_RELEASE
+			this_amount += days_rented * 3
+		when Movie::CHILDRENS
+			this_amount += 1.5
+			this_amount += (days_rented - 3) * 1.5 if days_rented > 3
+		end
+	end
+
+	def frequent_renter_points
+		movie.price_code == Movie.NEW_RELEASE && days_rented > 1 ? 2 : 1
+	end
 end
 
 class Customer
@@ -35,16 +53,12 @@ class Customer
 		total_amount, frequent_renter_points = 0, 0
 		result = "Rental Record for #{@name}\n"
 		@rentals.each do |element|
-			this_amount = amount_for(element)
-
 			frequent_renter_points += 1
 
-			if element.movie.price_code == Movie.NEW_RELEASE && element.days_rented > 1
-				frequent_renter_points += 1
-			end
+			element.frequent_renter_points
 
-			result += '\t' + element.movie.title + '\t' + this_amount.to_s + '\n'
-			total_amount += this_amount
+			result += '\t' + element.movie.title + '\t' + element.charge.to_s + '\n'
+			total_amount += element.charge
 		end
 
 			result += "Amount owed is #{total_amount}\n"
@@ -52,17 +66,7 @@ class Customer
 			result
 	end
 
-	def amount_for(element)
-		this_amount = 0
-		case element.movie.price_code
-		when Movie::REGULAR
-			this_amount += 2
-			this_amount += (element.days_rented - 2) * 1.5 if element.days_rented > 2
-		when Movie::NEW_RELEASE
-			this_amount += element.days_rented * 3
-		when Movie::CHILDRENS
-			this_amount += 1.5
-			this_amount += (element.days_rented - 3) * 1.5 if element.days_rented > 3
-		end
+	def amount_for(rental)
+		rental.charge
 	end
 end


### PR DESCRIPTION
メソッドをさらに分割して、Rentalクラスに移動させる。
さらに、一時変数を除去して、直接呼び出すようにする。

理由としては、一時変数はスコープが狭いので、つけることで、メソッドが長くなってしまうことを助長する可能性があるらしい。
そのあたりは、さらに調査をする。